### PR TITLE
Fix Region Brick (and menu refactoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Don't place the WUP into any subfolders.
 Displays the current Parental Controls pin configuration.  
 Allows disabling Parental Controls.
 
+### Fix Region Brick
+Fixes bricks caused by setting productArea and/or gameRegion to an invalid
+value. Symptoms include being unable to launch System Settings or other
+in-region titles.
+
 ## Building
 ```bash
 # build the docker container

--- a/ios_mcp/source/gfx.c
+++ b/ios_mcp/source/gfx.c
@@ -185,10 +185,13 @@ static void gfx_draw_char(uint32_t x, uint32_t y, char c)
     }
 }
 
-void gfx_print(uint32_t x, uint32_t y, int alignRight, const char* string)
+void gfx_print(uint32_t x, uint32_t y, uint32_t gfxPrintFlags, const char* string)
 {
-    if (alignRight) {
+    if (gfxPrintFlags & GfxPrintFlag_AlignRight) {
         x -= gfx_get_text_width(string);
+    }
+    if (gfxPrintFlags & GfxPrintFlag_ClearBG) {
+        gfx_draw_rect_filled(x, y, CHAR_SIZE_DRC_X * gfx_get_text_width(string), CHAR_SIZE_DRC_Y, 0);
     }
 
     for (; *string != '\0'; string++, x += CHAR_SIZE_DRC_X) {
@@ -199,7 +202,7 @@ void gfx_print(uint32_t x, uint32_t y, int alignRight, const char* string)
     }
 }
 
-void gfx_printf(uint32_t x, uint32_t y, int alignRight, const char* format, ...)
+void gfx_printf(uint32_t x, uint32_t y, uint32_t gfxPrintFlags, const char* format, ...)
 {
     va_list args;
     va_start(args, format);
@@ -207,7 +210,7 @@ void gfx_printf(uint32_t x, uint32_t y, int alignRight, const char* format, ...)
     char buffer[0x100];
 
     vsnprintf(buffer, sizeof(buffer), format, args);
-    gfx_print(x, y, alignRight, buffer);
+    gfx_print(x, y, gfxPrintFlags, buffer);
 
     va_end(args);
 }

--- a/ios_mcp/source/gfx.h
+++ b/ios_mcp/source/gfx.h
@@ -25,7 +25,12 @@ void gfx_set_font_color(uint32_t col);
 
 uint32_t gfx_get_text_width(const char* string);
 
-void gfx_print(uint32_t x, uint32_t y, int alignRight, const char* string);
+typedef enum GfxPrintFlags {
+	GfxPrintFlag_AlignRight		= (1U << 0),
+	GfxPrintFlag_ClearBG		= (1U << 1),
+} GfxPrintFlags;
+
+void gfx_print(uint32_t x, uint32_t y, uint32_t gfxPrintFlags, const char* string);
 
 __attribute__((format(printf, 4, 5)))
-void gfx_printf(uint32_t x, uint32_t y, int alignRight, const char* format, ...);
+void gfx_printf(uint32_t x, uint32_t y, uint32_t gfxPrintFlags, const char* format, ...);

--- a/ios_mcp/source/gfx.h
+++ b/ios_mcp/source/gfx.h
@@ -27,4 +27,5 @@ uint32_t gfx_get_text_width(const char* string);
 
 void gfx_print(uint32_t x, uint32_t y, int alignRight, const char* string);
 
+__attribute__((format(printf, 4, 5)))
 void gfx_printf(uint32_t x, uint32_t y, int alignRight, const char* format, ...);

--- a/ios_mcp/source/mcp_install.c
+++ b/ios_mcp/source/mcp_install.c
@@ -40,7 +40,7 @@ int MCP_InstallGetInfo(int handle, const char* path, MCPInstallInfo* out_info)
     return res;
 }
 
-int MCP_SetTargetUsb(int handle, int target)
+int MCP_InstallSetTargetUsb(int handle, int target)
 {
     uint32_t* buf = allocIoBuf(4);
     memcpy(buf, &target, 4);

--- a/ios_mcp/source/mcp_install.h
+++ b/ios_mcp/source/mcp_install.h
@@ -18,7 +18,7 @@ typedef struct __attribute__((packed)) {
 
 int MCP_InstallGetInfo(int handle, const char* path, MCPInstallInfo* out_info);
 
-int MCP_SetTargetUsb(int handle, int target);
+int MCP_InstallSetTargetUsb(int handle, int target);
 
 int MCP_InstallSetTargetDevice(int handle, int device);
 

--- a/ios_mcp/source/mcp_misc.c
+++ b/ios_mcp/source/mcp_misc.c
@@ -32,3 +32,18 @@ int MCP_GetSysProdSettings(int handle, MCPSysProdSettings* out_sysProdSettings)
 
     return res;
 }
+
+int MCP_SetSysProdSettings(int handle, const MCPSysProdSettings* sysProdSettings)
+{
+    uint8_t* buf = allocIoBuf(sizeof(IOSVec_t) + sizeof(*sysProdSettings));
+    memcpy(&buf[sizeof(IOSVec_t)], sysProdSettings, sizeof(*sysProdSettings));
+
+    IOSVec_t* vecs = (IOSVec_t*)buf;
+    vecs[0].ptr = buf + sizeof(IOSVec_t);
+    vecs[0].len = sizeof(*sysProdSettings);
+
+    int res = IOS_Ioctlv(handle, 0x41, 1, 0, vecs);
+    freeIoBuf(buf);
+
+    return res;
+}

--- a/ios_mcp/source/mcp_misc.h
+++ b/ios_mcp/source/mcp_misc.h
@@ -38,3 +38,5 @@ typedef struct __attribute__((packed)) _MCPSysProdSettings {
 static_assert(sizeof(MCPSysProdSettings) == 0x46, "MCPSysProdSettings: different size than expected");
 
 int MCP_GetSysProdSettings(int handle, MCPSysProdSettings* out_sysProdSettings);
+
+int MCP_SetSysProdSettings(int handle, const MCPSysProdSettings* sysProdSettings);

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -293,10 +293,18 @@ static void option_SetColdbootTitle(void)
 
         if (newtid) {
             index += (CHAR_SIZE_DRC_Y + 4) * 2;
+
+            gfx_draw_rect_filled(16 - 1, index - 1,
+                (CHAR_SIZE_DRC_X * (38+8+8+3)) + 2, CHAR_SIZE_DRC_Y + 2,
+                COLOR_BACKGROUND);
             gfx_set_font_color(COLOR_PRIMARY);
             gfx_printf(16, index, 0, "Setting coldboot title id to %08x-%08x, rval %d",
                 (uint32_t)(newtid >> 32), (uint32_t)(newtid & 0xFFFFFFFFU), rval);
             index += CHAR_SIZE_DRC_Y + 4;
+
+            gfx_draw_rect_filled(16 - 1, index - 1,
+                (CHAR_SIZE_DRC_X * 47) + 2, CHAR_SIZE_DRC_Y + 2,
+                COLOR_BACKGROUND);
             if (rval < 0) {
                 gfx_set_font_color(COLOR_ERROR);
                 gfx_printf(16, index, 0, "Error! Make sure title is installed correctly.");

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -103,7 +103,7 @@ static void drawBars(const char* title)
     // draw bottom bar
     gfx_draw_rect_filled(8, SCREEN_HEIGHT - (16 + 8 + 2), SCREEN_WIDTH - 8 * 2, 2, COLOR_SECONDARY);
     gfx_print(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "EJECT: Navigate");
-    gfx_print(SCREEN_WIDTH - 16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 1, "POWER: Choose");
+    gfx_print(SCREEN_WIDTH - 16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, GfxPrintFlag_AlignRight, "POWER: Choose");
 }
 
 typedef enum {
@@ -215,7 +215,7 @@ static void waitButtonInput(void)
     gfx_draw_rect_filled(8, SCREEN_HEIGHT - (16 + 8 + 2), SCREEN_WIDTH - 8 * 2, 2, COLOR_SECONDARY);
 
     gfx_draw_rect_filled(16 - 1, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4,
-        854 - 16, CHAR_SIZE_DRC_Y + 2,
+        SCREEN_WIDTH - 16, CHAR_SIZE_DRC_Y + 2,
         COLOR_BACKGROUND);
     gfx_print(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "Press EJECT or POWER to proceed...");
 
@@ -280,17 +280,11 @@ static void option_SetColdbootTitle(void)
         gfx_set_font_color(COLOR_PRIMARY);
 
         // draw current titles
-        gfx_draw_rect_filled(16 - 1, index - 1,
-            (CHAR_SIZE_DRC_X * (28+8+8)) + 2, CHAR_SIZE_DRC_Y + 2,
-            COLOR_BACKGROUND);
-        gfx_printf(16, index, 0, "Current coldboot title:    %08lx-%08lx",
+        gfx_printf(16, index, GfxPrintFlag_ClearBG, "Current coldboot title:    %08lx-%08lx",
             (uint32_t)(currentColdbootTitle >> 32), (uint32_t)(currentColdbootTitle & 0xFFFFFFFFU));
         index += CHAR_SIZE_DRC_Y + 4;
 
-        gfx_draw_rect_filled(16 - 1, index - 1,
-            (CHAR_SIZE_DRC_X * (28+8+8)) + 2, CHAR_SIZE_DRC_Y + 2,
-            COLOR_BACKGROUND);
-        gfx_printf(16, index, 0, "Current coldboot os:       %08lx-%08lx",
+        gfx_printf(16, index, GfxPrintFlag_ClearBG, "Current coldboot os:       %08lx-%08lx",
             (uint32_t)(currentColdbootOS >> 32), (uint32_t)(currentColdbootOS & 0xFFFFFFFFU));
         index += (CHAR_SIZE_DRC_Y + 4) * 2;
 
@@ -309,23 +303,18 @@ static void option_SetColdbootTitle(void)
         if (newtid) {
             index += (CHAR_SIZE_DRC_Y + 4) * 2;
 
-            gfx_draw_rect_filled(16 - 1, index - 1,
-                (CHAR_SIZE_DRC_X * (37+8+8+11)) + 2, CHAR_SIZE_DRC_Y + 2,
-                COLOR_BACKGROUND);
             gfx_set_font_color(COLOR_PRIMARY);
-            gfx_printf(16, index, 0, "Setting coldboot title id to %08lx-%08lx, rval %d",
+            gfx_printf(16, index, GfxPrintFlag_ClearBG,
+                "Setting coldboot title id to %08lx-%08lx, rval %d  ",
                 (uint32_t)(newtid >> 32), (uint32_t)(newtid & 0xFFFFFFFFU), rval);
             index += CHAR_SIZE_DRC_Y + 4;
 
-            gfx_draw_rect_filled(16 - 1, index - 1,
-                (CHAR_SIZE_DRC_X * 46) + 2, CHAR_SIZE_DRC_Y + 2,
-                COLOR_BACKGROUND);
             if (rval < 0) {
                 gfx_set_font_color(COLOR_ERROR);
-                gfx_print(16, index, 0, "Error! Make sure title is installed correctly.");
+                gfx_print(16, index, GfxPrintFlag_ClearBG, "Error! Make sure title is installed correctly.");
             } else {
                 gfx_set_font_color(COLOR_SUCCESS);
-                gfx_print(16, index, 0, "Success!");
+                gfx_print(16, index, GfxPrintFlag_ClearBG, "Success!                                      ");
             }
         }
     }
@@ -899,31 +888,26 @@ static void option_EditParental(void)
         gfx_set_font_color(COLOR_PRIMARY);
 
         // draw current parental control info
-        gfx_draw_rect_filled(16 - 1, index - 1,
-            (CHAR_SIZE_DRC_X * (29+11)) + 2, CHAR_SIZE_DRC_Y + 2,
-            COLOR_BACKGROUND);
         uint8_t enabled = 0;
         int res = SCIGetParentalEnable(&enabled);
         if (res == 1) {
             gfx_set_font_color(COLOR_PRIMARY);
-            gfx_printf(16, index, 0, "Parental Controls: %s", enabled ? "Enabled" : "Disabled");
+            gfx_printf(16, index, GfxPrintFlag_ClearBG, "Parental Controls: %s ",
+                enabled ? "Enabled" : "Disabled");
         } else {
             gfx_set_font_color(COLOR_ERROR);
-            gfx_printf(16, index, 0, "SCIGetParentalEnable failed: %d", res);
+            gfx_printf(16, index, GfxPrintFlag_ClearBG, "SCIGetParentalEnable failed: %d  ", res);
         }
         index += CHAR_SIZE_DRC_Y + 4;
 
-        gfx_draw_rect_filled(16 - 1, index - 1,
-            (CHAR_SIZE_DRC_X * (30+3)) + 2, CHAR_SIZE_DRC_Y + 2,
-            COLOR_BACKGROUND);
         char pin[5] = "";
         res = SCIGetParentalPinCode(pin, sizeof(pin));
         if (res == 1) {
             gfx_set_font_color(COLOR_PRIMARY);
-            gfx_printf(16, index, 0, "Parental Pin Code: %s", pin);
+            gfx_printf(16, index, GfxPrintFlag_ClearBG, "Parental Pin Code: %s", pin);
         } else {
             gfx_set_font_color(COLOR_ERROR);
-            gfx_printf(16, index, 0, "SCIGetParentalPinCode failed: %d", res);
+            gfx_printf(16, index, GfxPrintFlag_ClearBG, "SCIGetParentalPinCode failed: %d  ", res);
         }
         index += (CHAR_SIZE_DRC_Y + 4) * 2;
 

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -55,17 +55,6 @@ extern uint64_t currentColdbootTitle;
 
 static int fsaHandle = -1;
 
-/**
- * Number of elements in an array.
- *
- * Includes a static check for pointers to make sure
- * a dynamically-allocated array wasn't specified.
- * Reference: http://stackoverflow.com/questions/8018843/macro-definition-array-size
- */
-#define ARRAY_SIZE(x) \
-	(((sizeof(x) / sizeof(x[0]))) / \
-		(size_t)(!(sizeof(x) % sizeof(x[0]))))
-
 typedef struct Menu {
     const char* name;
     union {

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -1044,18 +1044,15 @@ static void option_FixRegionBrick(void)
     const char* menu_region_str;
     if (menu_count == 0 || menu_productArea_id < 0) {
         menu_region_str = "NONE";
+        gfx_set_font_color(COLOR_ERROR);
     } else if (menu_count > 1) {
         menu_region_str = "MANY";
+        gfx_set_font_color(COLOR_ERROR);
     } else {
         menu_region_str = region_tbl[menu_productArea_id];
+        gfx_set_font_color(COLOR_SUCCESS);
     }
 
-    if (menu_matches_region && menu_is_in_gameRegion && menu_count == 1) {
-        // Matching menu found.
-        gfx_set_font_color(COLOR_SUCCESS);
-    } else {
-        gfx_set_font_color(COLOR_ERROR);
-    }
     gfx_print(16+(22*CHAR_SIZE_DRC_X), index, 0, menu_region_str);
     index += CHAR_SIZE_DRC_Y + 4;
 
@@ -1269,8 +1266,8 @@ static void option_SystemInformation(void)
     }
 
     // Wii U Menu version
-    // FIXME: CAT-I has all three region versions installed.
-    // Need to get the actual productArea from sys_prod.xml.
+    // NOTE: If productArea doesn't match the installed Wii U Menu,
+    // the Wii U Menu version won't be displayed.
 #define VERSION_BIN_MAGIC_STR "VER\0"
 #define VERSION_BIN_MAGIC_U32 0x56455200
     typedef struct _version_bin_t {

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -262,7 +262,6 @@ static void option_SetColdbootTitle(void)
 
     int rval;
     uint64_t newtid = 0;
-    int menu_flags = MenuFlag_ShowTID | MenuFlag_NoClearScreen;
 
     gfx_clear(COLOR_BACKGROUND);
     while (1) {
@@ -270,16 +269,23 @@ static void option_SetColdbootTitle(void)
         gfx_set_font_color(COLOR_PRIMARY);
 
         // draw current titles
+        gfx_draw_rect_filled(16 - 1, index - 1,
+            (CHAR_SIZE_DRC_X * (28+8+8)) + 2, CHAR_SIZE_DRC_Y + 2,
+            COLOR_BACKGROUND);
         gfx_printf(16, index, 0, "Current coldboot title:    %08x-%08x",
             (uint32_t)(currentColdbootTitle >> 32), (uint32_t)(currentColdbootTitle & 0xFFFFFFFFU));
         index += CHAR_SIZE_DRC_Y + 4;
 
+        gfx_draw_rect_filled(16 - 1, index - 1,
+            (CHAR_SIZE_DRC_X * (28+8+8)) + 2, CHAR_SIZE_DRC_Y + 2,
+            COLOR_BACKGROUND);
         gfx_printf(16, index, 0, "Current coldboot os:       %08x-%08x",
             (uint32_t)(currentColdbootOS >> 32), (uint32_t)(currentColdbootOS & 0xFFFFFFFFU));
         index += (CHAR_SIZE_DRC_Y + 4) * 2;
 
         int selected = drawMenu("Set Coldboot Title",
-            coldbootTitleOptions, option_count, menu_flags, 16, index);
+            coldbootTitleOptions, option_count,
+            MenuFlag_ShowTID | MenuFlag_NoClearScreen, 16, index);
         index += (CHAR_SIZE_DRC_Y + 4) * option_count;
 
         newtid = coldbootTitleOptions[selected].tid;
@@ -288,14 +294,12 @@ static void option_SetColdbootTitle(void)
 
         // set the new default title ID
         rval = setDefaultTitleId(newtid);
-        // don't clear the screen on the next menu draw
-        menu_flags |= MenuFlag_NoClearScreen;
 
         if (newtid) {
             index += (CHAR_SIZE_DRC_Y + 4) * 2;
 
             gfx_draw_rect_filled(16 - 1, index - 1,
-                (CHAR_SIZE_DRC_X * (38+8+8+3)) + 2, CHAR_SIZE_DRC_Y + 2,
+                (CHAR_SIZE_DRC_X * (37+8+8+3)) + 2, CHAR_SIZE_DRC_Y + 2,
                 COLOR_BACKGROUND);
             gfx_set_font_color(COLOR_PRIMARY);
             gfx_printf(16, index, 0, "Setting coldboot title id to %08x-%08x, rval %d",
@@ -303,7 +307,7 @@ static void option_SetColdbootTitle(void)
             index += CHAR_SIZE_DRC_Y + 4;
 
             gfx_draw_rect_filled(16 - 1, index - 1,
-                (CHAR_SIZE_DRC_X * 47) + 2, CHAR_SIZE_DRC_Y + 2,
+                (CHAR_SIZE_DRC_X * 46) + 2, CHAR_SIZE_DRC_Y + 2,
                 COLOR_BACKGROUND);
             if (rval < 0) {
                 gfx_set_font_color(COLOR_ERROR);

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -836,7 +836,7 @@ static void option_InstallWUP(void)
     res = MCP_InstallSetTargetUsb(mcpHandle, 0);
     if (res < 0) {
         gfx_set_font_color(COLOR_ERROR);
-        gfx_printf(16, index, 0, "MCP_InstallSetTargetDevice: %x", res);
+        gfx_printf(16, index, 0, "MCP_InstallSetTargetUsb: %x", res);
         waitButtonInput();
 
         IOS_Close(mcpHandle);

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -1132,7 +1132,7 @@ static void option_FixRegionBrick(void)
         {menuItem, {0} },
     };
     int selected = drawMenu("Fix Region Brick",
-        fixRegionBrickOptions, ARRAY_SIZE(fixRegionBrickOptions), selected,
+        fixRegionBrickOptions, ARRAY_SIZE(fixRegionBrickOptions), 0,
         MenuFlag_NoClearScreen, 16, index);
     if (selected == 0)
         return;

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -283,14 +283,14 @@ static void option_SetColdbootTitle(void)
         gfx_draw_rect_filled(16 - 1, index - 1,
             (CHAR_SIZE_DRC_X * (28+8+8)) + 2, CHAR_SIZE_DRC_Y + 2,
             COLOR_BACKGROUND);
-        gfx_printf(16, index, 0, "Current coldboot title:    %08x-%08x",
+        gfx_printf(16, index, 0, "Current coldboot title:    %08lx-%08lx",
             (uint32_t)(currentColdbootTitle >> 32), (uint32_t)(currentColdbootTitle & 0xFFFFFFFFU));
         index += CHAR_SIZE_DRC_Y + 4;
 
         gfx_draw_rect_filled(16 - 1, index - 1,
             (CHAR_SIZE_DRC_X * (28+8+8)) + 2, CHAR_SIZE_DRC_Y + 2,
             COLOR_BACKGROUND);
-        gfx_printf(16, index, 0, "Current coldboot os:       %08x-%08x",
+        gfx_printf(16, index, 0, "Current coldboot os:       %08lx-%08lx",
             (uint32_t)(currentColdbootOS >> 32), (uint32_t)(currentColdbootOS & 0xFFFFFFFFU));
         index += (CHAR_SIZE_DRC_Y + 4) * 2;
 
@@ -313,7 +313,7 @@ static void option_SetColdbootTitle(void)
                 (CHAR_SIZE_DRC_X * (37+8+8+11)) + 2, CHAR_SIZE_DRC_Y + 2,
                 COLOR_BACKGROUND);
             gfx_set_font_color(COLOR_PRIMARY);
-            gfx_printf(16, index, 0, "Setting coldboot title id to %08x-%08x, rval %d",
+            gfx_printf(16, index, 0, "Setting coldboot title id to %08lx-%08lx, rval %d",
                 (uint32_t)(newtid >> 32), (uint32_t)(newtid & 0xFFFFFFFFU), rval);
             index += CHAR_SIZE_DRC_Y + 4;
 
@@ -607,7 +607,7 @@ static void network_parse_config_value(uint32_t* console_idx, NetConfCfg* cfg, c
             }
         }
     } else if (strncmp(key, "ssid", sizeof("ssid")) == 0) {
-        gfx_printf(16, *console_idx, 0, "SSID: %s (%d)", value, value_len);
+        gfx_printf(16, *console_idx, 0, "SSID: %s (%lu)", value, value_len);
         (*console_idx) += CHAR_SIZE_DRC_Y + 4;
 
         if (value) {
@@ -615,7 +615,7 @@ static void network_parse_config_value(uint32_t* console_idx, NetConfCfg* cfg, c
             cfg->wifi.config.ssidlength = value_len;
         }
     } else if (strncmp(key, "key", sizeof("key")) == 0) {
-        gfx_printf(16, *console_idx, 0, "Key: ******* (%d)", value_len);
+        gfx_printf(16, *console_idx, 0, "Key: ******* (%lu)", value_len);
         (*console_idx) += CHAR_SIZE_DRC_Y + 4;
 
         if (value) {
@@ -1338,7 +1338,7 @@ static void option_SystemInformation(void)
             // Did we find a valid version.bin?
             if (version_bin->ver_magic.u32 == VERSION_BIN_MAGIC_U32) {
                 // Found a valid version.bin.
-                gfx_printf(16, index, 0, "Wii U Menu version: %u.%u.%u %c",
+                gfx_printf(16, index, 0, "Wii U Menu version: %lu.%lu.%lu %c",
                     version_bin->major, version_bin->minor, version_bin->revision, version_bin->region);
                 index += CHAR_SIZE_DRC_Y + 4;
             }

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -146,15 +146,19 @@ static void drawMenuItem(const Menu* menuItem, int selected, uint32_t flags, uin
  * @param title Menu title
  * @param menu Array of menu entries
  * @param count Number of menu entries
+ * @param selected Initial selected item index
  * @param flags
  * @param x
  * @param y
  * @return Selected menu entry index.
  */
-static int drawMenu(const char* title, const Menu* menu, size_t count, uint32_t flags, uint32_t x, uint32_t y)
+static int drawMenu(const char* title, const Menu* menu, size_t count,
+        int selected, uint32_t flags, uint32_t x, uint32_t y)
 {
     int redraw = 1;
-    int selected = 0, prev_selected = -1;
+    int prev_selected = -1;
+    if (selected < 0 || selected >= count)
+        selected = 0;
 
     // draw the full menu
     if (!(flags & MenuFlag_NoClearScreen)) {
@@ -262,6 +266,7 @@ static void option_SetColdbootTitle(void)
 
     int rval;
     uint64_t newtid = 0;
+    int selected = 0;
 
     gfx_clear(COLOR_BACKGROUND);
     while (1) {
@@ -283,8 +288,8 @@ static void option_SetColdbootTitle(void)
             (uint32_t)(currentColdbootOS >> 32), (uint32_t)(currentColdbootOS & 0xFFFFFFFFU));
         index += (CHAR_SIZE_DRC_Y + 4) * 2;
 
-        int selected = drawMenu("Set Coldboot Title",
-            coldbootTitleOptions, option_count,
+        selected = drawMenu("Set Coldboot Title",
+            coldbootTitleOptions, option_count, selected,
             MenuFlag_ShowTID | MenuFlag_NoClearScreen, 16, index);
         index += (CHAR_SIZE_DRC_Y + 4) * option_count;
 
@@ -879,6 +884,8 @@ static void option_EditParental(void)
     };
 
     int rval;
+    int selected = 0;
+
     gfx_clear(COLOR_BACKGROUND);
     while (1) {
         uint32_t index = 16 + 8 + 2 + 8;
@@ -915,8 +922,8 @@ static void option_EditParental(void)
 
         gfx_set_font_color(COLOR_PRIMARY);
 
-        int selected = drawMenu("Edit Parental Controls",
-            parentalControlOptions, ARRAY_SIZE(parentalControlOptions),
+        selected = drawMenu("Edit Parental Controls",
+            parentalControlOptions, ARRAY_SIZE(parentalControlOptions), selected,
             MenuFlag_NoClearScreen, 16, index);
         index += (CHAR_SIZE_DRC_Y + 4) * ARRAY_SIZE(parentalControlOptions);
 
@@ -1200,9 +1207,11 @@ int menuThread(void* arg)
         printf("Failed to open FSA: %x\n", fsaHandle);
     }
 
+    int selected = 0;
     while (1) {
-        int selected = drawMenu("Wii U Recovery Menu v0.2 by GaryOderNichts",
-            mainMenuOptions, ARRAY_SIZE(mainMenuOptions), 0, 16, 16+8+2+8);
+        selected = drawMenu("Wii U Recovery Menu v0.2 by GaryOderNichts",
+            mainMenuOptions, ARRAY_SIZE(mainMenuOptions), selected,
+            0, 16, 16+8+2+8);
         if (selected >= 0 && selected < ARRAY_SIZE(mainMenuOptions)) {
             mainMenuOptions[selected].callback();
         }

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -841,7 +841,8 @@ static void option_InstallWUP(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Installing title: 0x%016llx...", info.titleId);
+    gfx_printf(16, index, 0, "Installing title: %08lx-%08lx...",
+        (uint32_t)(info.titleId >> 32), (uint32_t)(info.titleId & 0xFFFFFFFFU));
     index += CHAR_SIZE_DRC_Y + 4;
 
     // only install to NAND

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -213,6 +213,10 @@ static void waitButtonInput(void)
 {
     gfx_set_font_color(COLOR_PRIMARY);
     gfx_draw_rect_filled(8, SCREEN_HEIGHT - (16 + 8 + 2), SCREEN_WIDTH - 8 * 2, 2, COLOR_SECONDARY);
+
+    gfx_draw_rect_filled(16 - 1, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4,
+        (CHAR_SIZE_DRC_X * 34) + 2, CHAR_SIZE_DRC_Y + 2,
+        COLOR_BACKGROUND);
     gfx_printf(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "Press EJECT or POWER to proceed...");
 
     uint8_t cur_flag = 0;

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -855,7 +855,7 @@ static void option_InstallWUP(void)
         IOS_Close(mcpHandle);
         return;
     }
-    res = MCP_SetTargetUsb(mcpHandle, 0);
+    res = MCP_InstallSetTargetUsb(mcpHandle, 0);
     if (res < 0) {
         gfx_set_font_color(COLOR_ERROR);
         gfx_printf(16, index, 0, "MCP_InstallSetTargetDevice: %x", res);

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -997,11 +997,6 @@ static void option_FixRegionBrick(void)
     gfx_clear(COLOR_BACKGROUND);
     drawTopBar("Fix Region Brick");
 
-    Menu fixSimpleBrick[] = {
-        {"Back", {0} },
-        {"Set Region to XXX", {0} },
-    };
-
     uint32_t index = 16 + 8 + 2 + 8;
 
     // Get the system region code, then check if a matching
@@ -1104,8 +1099,27 @@ static void option_FixRegionBrick(void)
         gfx_print(16, index, 0, "The game region does not match the installed Wii U Menu.");
         index += CHAR_SIZE_DRC_Y + 4;
     }
+    index += CHAR_SIZE_DRC_Y + 4;
 
     gfx_set_font_color(COLOR_PRIMARY);
+    gfx_printf(16, index, 0, "Repair the system by setting the region code to %s?", menu_region_str);
+    index += CHAR_SIZE_DRC_Y + 4;
+
+    char menuItem[] = "Set Region to XXX";
+    menuItem[14] = menu_region_str[0];
+    menuItem[15] = menu_region_str[1];
+    menuItem[16] = menu_region_str[2];
+
+    const Menu fixRegionBrickOptions[] = {
+        {"Cancel", {0} },
+        {menuItem, {0} },
+    };
+    int selected = drawMenu("Fix Region Brick",
+        fixRegionBrickOptions, ARRAY_SIZE(fixRegionBrickOptions), selected,
+        MenuFlag_NoClearScreen, 16, index);
+    if (selected == 0)
+        return;
+
     waitButtonInput();
 }
 

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -913,21 +913,15 @@ static void option_EditParental(void)
         // Option 1: Disable the parental controls.
         rval = SCISetParentalEnable(0);
 
-        gfx_draw_rect_filled(16 - 1, index - 1,
-            (CHAR_SIZE_DRC_X * (29+11)) + 2, CHAR_SIZE_DRC_Y + 2,
-            COLOR_BACKGROUND);
-        gfx_printf(16, index, 0, "SCISetParentalEnable(false): %d", rval);
+        gfx_printf(16, index, GfxPrintFlag_ClearBG, "SCISetParentalEnable(false): %d  ", rval);
         index += CHAR_SIZE_DRC_Y + 4;
 
-        gfx_draw_rect_filled(16 - 1, index - 1,
-            (CHAR_SIZE_DRC_X * 8) + 2, CHAR_SIZE_DRC_Y + 2,
-            COLOR_BACKGROUND);
         if (rval != 1) {
             gfx_set_font_color(COLOR_ERROR);
-            gfx_print(16, index, 0, "Error!");
+            gfx_print(16, index, GfxPrintFlag_ClearBG, "Error!  ");
         } else {
             gfx_set_font_color(COLOR_SUCCESS);
-            gfx_print(16, index, 0, "Success!");
+            gfx_print(16, index, GfxPrintFlag_ClearBG, "Success!");
         }
         index += CHAR_SIZE_DRC_Y + 4;
     }

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -92,7 +92,7 @@ static void drawTopBar(const char* title)
 {
     // draw top bar
     gfx_set_font_color(COLOR_PRIMARY);
-    gfx_printf((SCREEN_WIDTH / 2) + (gfx_get_text_width(title) / 2), 8, 1, title);
+    gfx_print((SCREEN_WIDTH / 2) + (gfx_get_text_width(title) / 2), 8, 1, title);
     gfx_draw_rect_filled(8, 16 + 8, SCREEN_WIDTH - 8 * 2, 2, COLOR_SECONDARY);
 }
 
@@ -102,8 +102,8 @@ static void drawBars(const char* title)
 
     // draw bottom bar
     gfx_draw_rect_filled(8, SCREEN_HEIGHT - (16 + 8 + 2), SCREEN_WIDTH - 8 * 2, 2, COLOR_SECONDARY);
-    gfx_printf(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "EJECT: Navigate");
-    gfx_printf(SCREEN_WIDTH - 16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 1, "POWER: Choose");
+    gfx_print(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "EJECT: Navigate");
+    gfx_print(SCREEN_WIDTH - 16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 1, "POWER: Choose");
 }
 
 typedef enum {
@@ -217,7 +217,7 @@ static void waitButtonInput(void)
     gfx_draw_rect_filled(16 - 1, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4,
         854 - 16, CHAR_SIZE_DRC_Y + 2,
         COLOR_BACKGROUND);
-    gfx_printf(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "Press EJECT or POWER to proceed...");
+    gfx_print(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "Press EJECT or POWER to proceed...");
 
     uint8_t cur_flag = 0;
     uint8_t flag = 0;
@@ -322,10 +322,10 @@ static void option_SetColdbootTitle(void)
                 COLOR_BACKGROUND);
             if (rval < 0) {
                 gfx_set_font_color(COLOR_ERROR);
-                gfx_printf(16, index, 0, "Error! Make sure title is installed correctly.");
+                gfx_print(16, index, 0, "Error! Make sure title is installed correctly.");
             } else {
                 gfx_set_font_color(COLOR_SUCCESS);
-                gfx_printf(16, index, 0, "Success!");
+                gfx_print(16, index, 0, "Success!");
             }
         }
     }
@@ -338,7 +338,7 @@ static void option_DumpSyslogs(void)
     drawTopBar("Dumping Syslogs...");
 
     uint32_t index = 16 + 8 + 2 + 8;
-    gfx_printf(16, index, 0, "Creating 'logs' directory...");
+    gfx_print(16, index, 0, "Creating 'logs' directory...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int res = FSA_MakeDir(fsaHandle, "/vol/storage_recovsd/logs", 0x600);
@@ -349,7 +349,7 @@ static void option_DumpSyslogs(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Opening system 'logs' directory...");
+    gfx_print(16, index, 0, "Opening system 'logs' directory...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int dir_handle;
@@ -389,7 +389,7 @@ static void option_DumpSyslogs(void)
 
     index += CHAR_SIZE_DRC_Y + 4;
     gfx_set_font_color(COLOR_SUCCESS);
-    gfx_printf(16, index, 0, "Done!");
+    gfx_print(16, index, 0, "Done!");
     waitButtonInput();
 
     FSA_CloseDir(fsaHandle, dir_handle);
@@ -401,13 +401,13 @@ static void option_DumpOtpAndSeeprom(void)
     drawTopBar("Dumping OTP + SEEPROM...");
 
     uint32_t index = 16 + 8 + 2 + 8;
-    gfx_printf(16, index, 0, "Creating otp.bin...");
+    gfx_print(16, index, 0, "Creating otp.bin...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     void* dataBuffer = IOS_HeapAllocAligned(0xcaff, 0x400, 0x40);
     if (!dataBuffer) {
         gfx_set_font_color(COLOR_ERROR);
-        gfx_printf(16, index, 0, "Out of memory!");
+        gfx_print(16, index, 0, "Out of memory!");
         waitButtonInput();
         return;
     }
@@ -423,7 +423,7 @@ static void option_DumpOtpAndSeeprom(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Reading OTP...");
+    gfx_print(16, index, 0, "Reading OTP...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     res = readOTP(dataBuffer, 0x400);
@@ -437,7 +437,7 @@ static void option_DumpOtpAndSeeprom(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Writing otp.bin...");
+    gfx_print(16, index, 0, "Writing otp.bin...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     res = FSA_WriteFile(fsaHandle, dataBuffer, 1, 0x400, otpHandle, 0);
@@ -453,7 +453,7 @@ static void option_DumpOtpAndSeeprom(void)
 
     FSA_CloseFile(fsaHandle, otpHandle);
 
-    gfx_printf(16, index, 0, "Creating seeprom.bin...");
+    gfx_print(16, index, 0, "Creating seeprom.bin...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int seepromHandle;
@@ -467,7 +467,7 @@ static void option_DumpOtpAndSeeprom(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Reading SEEPROM...");
+    gfx_print(16, index, 0, "Reading SEEPROM...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     res = EEPROM_Read(0, 0x100, (uint16_t*) dataBuffer);
@@ -481,7 +481,7 @@ static void option_DumpOtpAndSeeprom(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Writing seeprom.bin...");
+    gfx_print(16, index, 0, "Writing seeprom.bin...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     res = FSA_WriteFile(fsaHandle, dataBuffer, 1, 0x200, seepromHandle, 0);
@@ -496,7 +496,7 @@ static void option_DumpOtpAndSeeprom(void)
     }
 
     gfx_set_font_color(COLOR_SUCCESS);
-    gfx_printf(16, index, 0, "Done!");
+    gfx_print(16, index, 0, "Done!");
     waitButtonInput();
 
     FSA_CloseFile(fsaHandle, seepromHandle);
@@ -509,7 +509,7 @@ static void option_StartWupserver(void)
     drawTopBar("Running wupserver...");
 
     uint32_t index = 16 + 8 + 2 + 8;
-    gfx_printf(16, index, 0, "Initializing netconf...");
+    gfx_print(16, index, 0, "Initializing netconf...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int res = netconf_init();
@@ -520,7 +520,7 @@ static void option_StartWupserver(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Waiting for network connection... 5s");
+    gfx_printf(16, index, 0, "Waiting for network connection... %ds", 5);
 
     NetConfInterfaceTypeEnum interface = 0xff;
     for (int i = 0; i < 5; i++) {
@@ -543,7 +543,7 @@ static void option_StartWupserver(void)
 
     if (interface == 0xff) {
         gfx_set_font_color(COLOR_ERROR);
-        gfx_printf(16, index, 0, "No network connection!");
+        gfx_print(16, index, 0, "No network connection!");
         waitButtonInput();
         return;
     }
@@ -575,13 +575,13 @@ static void option_StartWupserver(void)
     wupserver_init();
 
     gfx_set_font_color(COLOR_SUCCESS);
-    gfx_printf(16, index, 0, "Wupserver running. Press EJECT or POWER to stop.");
+    gfx_print(16, index, 0, "Wupserver running. Press EJECT or POWER to stop.");
     index += CHAR_SIZE_DRC_Y + 4;
 
     waitButtonInput();
 
     gfx_set_font_color(COLOR_PRIMARY);
-    gfx_printf(16, index, 0, "Stopping wupserver...");
+    gfx_print(16, index, 0, "Stopping wupserver...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     wupserver_deinit();
@@ -640,7 +640,7 @@ static void network_parse_config_value(uint32_t* console_idx, NetConfCfg* cfg, c
             } else if (strncmp(value, "WPA_PSK_AES", sizeof("WPA_PSK_AES")) == 0) {
                 cfg->wifi.config.privacy.mode = NET_CFG_WIFI_PRIVACY_MODE_WPA_PSK_AES;
             } else {
-                gfx_printf(16, *console_idx, 0, "Unknown key type!");
+                gfx_print(16, *console_idx, 0, "Unknown key type!");
                 (*console_idx) += CHAR_SIZE_DRC_Y + 4;
             }
         }
@@ -653,7 +653,7 @@ static void option_LoadNetConf(void)
     drawTopBar("Loading network configuration...");
 
     uint32_t index = 16 + 8 + 2 + 8;
-    gfx_printf(16, index, 0, "Initializing netconf...");
+    gfx_print(16, index, 0, "Initializing netconf...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int res = netconf_init();
@@ -664,7 +664,7 @@ static void option_LoadNetConf(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Reading network.cfg...");
+    gfx_print(16, index, 0, "Reading network.cfg...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int cfgHandle;
@@ -690,7 +690,7 @@ static void option_LoadNetConf(void)
     char* cfgBuffer = (char*) IOS_HeapAllocAligned(0xcaff, stat.size + 1, 0x40);
     if (!cfgBuffer) {
         gfx_set_font_color(COLOR_ERROR);
-        gfx_printf(16, index, 0, "Out of memory!");
+        gfx_print(16, index, 0, "Out of memory!");
         waitButtonInput();
 
         FSA_CloseFile(fsaHandle, cfgHandle);
@@ -741,7 +741,7 @@ static void option_LoadNetConf(void)
         network_parse_config_value(&index, &cfg, keyPtr, valuePtr, (cfgBuffer + stat.size) - valuePtr);
     }
 
-    gfx_printf(16, index, 0, "Applying configuration...");
+    gfx_print(16, index, 0, "Applying configuration...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     res = netconf_set_running(&cfg);
@@ -756,7 +756,7 @@ static void option_LoadNetConf(void)
     }
 
     gfx_set_font_color(COLOR_SUCCESS);
-    gfx_printf(16, index, 0, "Done!");
+    gfx_print(16, index, 0, "Done!");
     index += CHAR_SIZE_DRC_Y + 4;
 
     waitButtonInput();
@@ -771,7 +771,7 @@ static void option_displayDRCPin(void)
     drawTopBar("Display DRC Pin");
 
     uint32_t index = 16 + 8 + 2 + 8;
-    gfx_printf(16, index, 0, "Reading DRH mac address...");
+    gfx_print(16, index, 0, "Reading DRH mac address...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int ccrHandle = IOS_Open("/dev/ccr_cdc", 0);
@@ -816,7 +816,7 @@ static void option_InstallWUP(void)
     drawTopBar("Installing WUP");
 
     uint32_t index = 16 + 8 + 2 + 8;
-    gfx_printf(16, index, 0, "Make sure to place a valid signed WUP directly in 'sd:/install'");
+    gfx_print(16, index, 0, "Make sure to place a valid signed WUP directly in 'sd:/install'");
     index += CHAR_SIZE_DRC_Y + 4;
 
     int mcpHandle = IOS_Open("/dev/mcp", 0);
@@ -827,7 +827,7 @@ static void option_InstallWUP(void)
         return;
     }
 
-    gfx_printf(16, index, 0, "Querying install info...");
+    gfx_print(16, index, 0, "Querying install info...");
     index += CHAR_SIZE_DRC_Y + 4;
 
     MCPInstallInfo info;
@@ -876,7 +876,7 @@ static void option_InstallWUP(void)
     }
 
     gfx_set_font_color(COLOR_SUCCESS);
-    gfx_printf(16, index, 0, "Done!");
+    gfx_print(16, index, 0, "Done!");
     waitButtonInput();
 
     IOS_Close(mcpHandle);
@@ -950,10 +950,10 @@ static void option_EditParental(void)
             COLOR_BACKGROUND);
         if (rval != 1) {
             gfx_set_font_color(COLOR_ERROR);
-            gfx_printf(16, index, 0, "Error!");
+            gfx_print(16, index, 0, "Error!");
         } else {
             gfx_set_font_color(COLOR_SUCCESS);
-            gfx_printf(16, index, 0, "Success!");
+            gfx_print(16, index, 0, "Success!");
         }
         index += CHAR_SIZE_DRC_Y + 4;
     }
@@ -1191,7 +1191,7 @@ static void option_SystemInformation(void)
     void *dataBuffer = IOS_HeapAllocAligned(0xcaff, 0x800, 0x40);
     if (!dataBuffer) {
         gfx_set_font_color(COLOR_ERROR);
-        gfx_printf(16, index, 0, "Out of memory!");
+        gfx_print(16, index, 0, "Out of memory!");
         waitButtonInput();
         return;
     }

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -215,7 +215,7 @@ static void waitButtonInput(void)
     gfx_draw_rect_filled(8, SCREEN_HEIGHT - (16 + 8 + 2), SCREEN_WIDTH - 8 * 2, 2, COLOR_SECONDARY);
 
     gfx_draw_rect_filled(16 - 1, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4,
-        (CHAR_SIZE_DRC_X * 34) + 2, CHAR_SIZE_DRC_Y + 2,
+        854 - 16, CHAR_SIZE_DRC_Y + 2,
         COLOR_BACKGROUND);
     gfx_printf(16, SCREEN_HEIGHT - CHAR_SIZE_DRC_Y - 4, 0, "Press EJECT or POWER to proceed...");
 

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -45,7 +45,7 @@ static void option_LoadNetConf(void);
 static void option_displayDRCPin(void);
 static void option_InstallWUP(void);
 static void option_EditParental(void);
-static void option_FixRegionBrick(void);
+static void option_DebugSystemRegion(void);
 static void option_SystemInformation(void);
 static void option_Shutdown(void);
 
@@ -72,7 +72,7 @@ static const Menu mainMenuOptions[] = {
     {"Display DRC Pin",             {.callback = option_displayDRCPin}},
     {"Install WUP",                 {.callback = option_InstallWUP}},
     {"Edit Parental Controls",      {.callback = option_EditParental}},
-    {"Fix Region Brick",            {.callback = option_FixRegionBrick}},
+    {"Debug System Region",         {.callback = option_DebugSystemRegion}},
     {"System Information",          {.callback = option_SystemInformation}},
     {"Shutdown",                    {.callback = option_Shutdown}},
 };
@@ -964,10 +964,10 @@ static int getRegionInfo(int* productArea_id, int* gameRegion)
     return 0;
 }
 
-static void option_FixRegionBrick(void)
+static void option_DebugSystemRegion(void)
 {
     gfx_clear(COLOR_BACKGROUND);
-    drawTopBar("Fix Region Brick");
+    drawTopBar("Debug System Region");
 
     uint32_t index = 16 + 8 + 2 + 8;
 
@@ -1092,7 +1092,7 @@ static void option_FixRegionBrick(void)
         {"Cancel", {0} },
         {"Fix Region", {0} },
     };
-    int selected = drawMenu("Fix Region Brick",
+    int selected = drawMenu("Debug System Region",
         fixRegionBrickOptions, ARRAY_SIZE(fixRegionBrickOptions), 0,
         MenuFlag_NoClearScreen, 16, index);
     if (selected == 0)

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -1124,10 +1124,8 @@ static void option_FixRegionBrick(void)
     gfx_printf(16, index, 0, "Repair the system by setting the region code to %s?", menu_region_str);
     index += CHAR_SIZE_DRC_Y + 4;
 
-    char menuItem[] = "Set Region to XXX";
-    menuItem[14] = menu_region_str[0];
-    menuItem[15] = menu_region_str[1];
-    menuItem[16] = menu_region_str[2];
+    char menuItem[20];
+    snprintf(menuItem, sizeof(menuItem), "Set Region to %s", menu_region_str);
 
     const Menu fixRegionBrickOptions[] = {
         {"Cancel", {0} },

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -1084,11 +1084,11 @@ static void option_FixRegionBrick(void)
     }
 
     if (!menu_matches_region) {
-        gfx_print(16, index, 0, "The system region does not match the installed Wii U Menu.");
+        gfx_printf(16, index, 0, "The %s region does not match the installed Wii U Menu.", "system");
         index += CHAR_SIZE_DRC_Y + 4;
     }
     if (!menu_is_in_gameRegion) {
-        gfx_print(16, index, 0, "The game region does not match the installed Wii U Menu.");
+        gfx_printf(16, index, 0, "The %s region does not match the installed Wii U Menu.", "game");
         index += CHAR_SIZE_DRC_Y + 4;
     }
     index += CHAR_SIZE_DRC_Y + 4;
@@ -1097,19 +1097,16 @@ static void option_FixRegionBrick(void)
     gfx_printf(16, index, 0, "Repair the system by setting the region code to %s?", menu_region_str);
     index += CHAR_SIZE_DRC_Y + 4;
 
-    char menuItem[20];
-    snprintf(menuItem, sizeof(menuItem), "Set Region to %s", menu_region_str);
-
-    const Menu fixRegionBrickOptions[] = {
+    static const Menu fixRegionBrickOptions[] = {
         {"Cancel", {0} },
-        {menuItem, {0} },
+        {"Fix Region", {0} },
     };
     int selected = drawMenu("Fix Region Brick",
         fixRegionBrickOptions, ARRAY_SIZE(fixRegionBrickOptions), 0,
         MenuFlag_NoClearScreen, 16, index);
     if (selected == 0)
         return;
-    index += (CHAR_SIZE_DRC_Y*3) + 4;
+    index += (CHAR_SIZE_DRC_Y*(ARRAY_SIZE(fixRegionBrickOptions)+1)) + 4;
 
     // Attempt to set the region code.
     int mcpHandle = IOS_Open("/dev/mcp", 0);

--- a/ios_mcp/source/menu.c
+++ b/ios_mcp/source/menu.c
@@ -137,15 +137,16 @@ static int drawMenu(const char* title, const Menu *menu, size_t count, uint32_t 
         if (redraw) {
             gfx_clear(COLOR_BACKGROUND);
 
+            int index = y;
             for (int i = 0; i < count; i++) {
-                gfx_draw_rect_filled(x - 1, y - 1,
+                gfx_draw_rect_filled(x - 1, index - 1,
                     gfx_get_text_width(menu[i].name) + 2, CHAR_SIZE_DRC_Y + 2,
                     selected == i ? COLOR_PRIMARY : COLOR_BACKGROUND);
 
                 gfx_set_font_color(selected == i ? COLOR_BACKGROUND : COLOR_PRIMARY);
-                gfx_printf(x, y, 0, menu[i].name);
+                gfx_printf(x, index, 0, menu[i].name);
 
-                y += CHAR_SIZE_DRC_Y + 4;
+                index += CHAR_SIZE_DRC_Y + 4;
             }
 
             gfx_set_font_color(COLOR_PRIMARY);

--- a/ios_mcp/source/utils.h
+++ b/ios_mcp/source/utils.h
@@ -1,6 +1,17 @@
 #pragma once
 #include <stdint.h>
 
+/**
+ * Number of elements in an array.
+ *
+ * Includes a static check for pointers to make sure
+ * a dynamically-allocated array wasn't specified.
+ * Reference: http://stackoverflow.com/questions/8018843/macro-definition-array-size
+ */
+#define ARRAY_SIZE(x) \
+	(((sizeof(x) / sizeof(x[0]))) / \
+		(size_t)(!(sizeof(x) % sizeof(x[0]))))
+
 #define SYSTEM_EVENT_FLAG_WAKE1            0x01
 #define SYSTEM_EVENT_FLAG_WAKE0            0x02
 #define SYSTEM_EVENT_FLAG_BT_INTERRUPT     0x04


### PR DESCRIPTION
This PR has two major changes:

1. Refactoring of the menu system to reduce flickering and improve code reuse.
2. "Fix Region Brick" option. This option compares productArea and gameRegion against installed Wii U Menus. If a Wii U Menu that matches productArea can't be found, then others are searched for. If one is found, the user will have the opportunity to change the productArea and gameRegion values to match the installed Wii U Menu.

Here's my CAT-DEV with productArea = KOR and gameRegion = TWN:
![LG_Smart_TV 2022-08-17 20-50-03](https://user-images.githubusercontent.com/6764716/185268806-222d73e5-e6eb-4b6b-9765-c2ab9c1127ed.jpg)

The system has a USA Wii U Menu installed, so let's fix it by setting the region to USA:
![LG_Smart_TV 2022-08-17 20-50-09](https://user-images.githubusercontent.com/6764716/185268869-956a3df0-9f39-4c38-b652-4342b6ab2b6f.jpg)

And verify by re-opening the "Fix Region Brick" menu afterwards:
![LG_Smart_TV 2022-08-17 20-50-13](https://user-images.githubusercontent.com/6764716/185268839-ed921bce-3274-4093-a266-6627339dc727.jpg)

Some notes:
* If no Wii U Menu is installed, it won't allow any region changes. This normally only happens on devkits using PCFS or freshly formatted with a DDI flash.
* gameRegion doesn't have to match the Wii U Menu exactly. For example, on a USA system, if gameRegion is set to JPN/USA/EUR, and platformArea is USA, this will be considered valid. The repair option always resets gameRegion to just productArea, though.